### PR TITLE
Fix/submit filters on change

### DIFF
--- a/app/routes/de.ich-suche-redezeit.tsx
+++ b/app/routes/de.ich-suche-redezeit.tsx
@@ -88,7 +88,7 @@ export default function SearchingCoach() {
             </fieldset>
             <fieldset className="mt-8">
               <legend className="mb-4 inline-block text-xl">
-                Filter by tag
+                Nach Thema filtern
               </legend>
               {tags.map((tag: ICoachtag) => {
                 const isNotSelectable =
@@ -119,7 +119,9 @@ export default function SearchingCoach() {
                 </button>
               </noscript>
               <span className="py-2 px-4 text-sm text-slate-400">
-                {coachesAmount} Zuhörer*innen gefunden.
+                {coachesAmount
+                  ? `${coachesAmount} Zuhörer*innen gefunden.`
+                  : `Keine Zuhörer*innen zu diesen Filtern gefunden :(`}
               </span>
             </div>
           </Form>

--- a/app/routes/de.ich-suche-redezeit.tsx
+++ b/app/routes/de.ich-suche-redezeit.tsx
@@ -90,18 +90,23 @@ export default function SearchingCoach() {
               <legend className="mb-4 inline-block text-xl">
                 Filter by tag
               </legend>
-              {tags.map((tag: ICoachtag) => (
-                <CoachFilterTag
-                  disabled={!availableTagIDs.includes(tag.sys.id)}
-                  key={tag.sys.id}
-                  value={tag.fields.tag}
-                  name="tag"
-                  defaultValue={checkedTags.includes(tag.fields.tag)}
-                  type="checkbox"
-                >
-                  {tag.fields.tag}
-                </CoachFilterTag>
-              ))}
+              {tags.map((tag: ICoachtag) => {
+                const isNotSelectable =
+                  !availableTagIDs.includes(tag.sys.id) &&
+                  !checkedTags.includes(tag.fields.tag);
+                return (
+                  <CoachFilterTag
+                    disabled={isNotSelectable}
+                    key={tag.sys.id}
+                    value={tag.fields.tag}
+                    name="tag"
+                    defaultValue={checkedTags.includes(tag.fields.tag)}
+                    type="checkbox"
+                  >
+                    {tag.fields.tag}
+                  </CoachFilterTag>
+                );
+              })}
             </fieldset>
             <div className="flex items-center gap-4">
               <noscript>

--- a/app/routes/de.ich-suche-redezeit.tsx
+++ b/app/routes/de.ich-suche-redezeit.tsx
@@ -1,8 +1,9 @@
-import { ICoach, ICoachtag } from "../../@types/generated/contentful";
-import { useLoaderData, useCatch, Form, useTransition } from "remix";
+import { useRef } from "react";
+import { useLoaderData, useCatch, Form, useTransition, useSubmit } from "remix";
 import type { LoaderFunction, MetaFunction } from "remix";
 import ContentBlocks from "~/components/ContentBlocks";
 import BasicLayout from "~/components/layout/BasicLayout";
+import { ICoachtag } from "../../@types/generated/contentful";
 import {
   getSearchPageContents,
   SearchPageContentResponse,
@@ -43,6 +44,15 @@ export default function SearchingCoach() {
     locale,
     availableTagIDs,
   } = useLoaderData();
+
+  const submit = useSubmit();
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleChange = () => {
+    if (formRef) {
+      submit(formRef.current, { replace: true });
+    }
+  };
   const state = useTransition();
   return (
     <BasicLayout nav={navigation.fields.items} lang={locale}>
@@ -52,7 +62,13 @@ export default function SearchingCoach() {
           <summary>
             <h5 className="inline-block text-xl">Filter anzeigen</h5>
           </summary>
-          <Form replace>
+          <Form
+            onChange={handleChange}
+            ref={formRef}
+            method="get"
+            id="filter-form"
+            className="flex flex-col gap-2"
+          >
             <fieldset className="mt-8">
               <legend className="mb-4 inline-block text-xl">
                 Filter by language
@@ -88,14 +104,16 @@ export default function SearchingCoach() {
               ))}
             </fieldset>
             <div className="flex items-center gap-4">
-              <button
-                className="font-inherit my-8 inline-flex items-center justify-center rounded-md bg-vsp-500 py-2 px-4 text-white no-underline transition-opacity duration-300 hover:opacity-90 focus:opacity-90 active:opacity-90 disabled:pointer-events-none disabled:bg-vsp-200 md:text-lg"
-                type="submit"
-                disabled={state.state === "submitting"}
-              >
-                Filter anwenden
-              </button>
-              <span className="text-sm text-slate-400">
+              <noscript>
+                <button
+                  className="font-inherit my-8 inline-flex items-center justify-center rounded-md bg-vsp-500 py-2 px-4 text-white no-underline transition-opacity duration-300 hover:opacity-90 focus:opacity-90 active:opacity-90 disabled:pointer-events-none disabled:bg-vsp-200 md:text-lg"
+                  type="submit"
+                  disabled={state.state === "submitting"}
+                >
+                  Filter anwenden
+                </button>
+              </noscript>
+              <span className="py-2 px-4 text-sm text-slate-400">
                 {coachesAmount} Zuhörer*innen gefunden.
               </span>
             </div>

--- a/app/routes/en.i-need-speaking-time.tsx
+++ b/app/routes/en.i-need-speaking-time.tsx
@@ -90,18 +90,23 @@ export default function SearchingCoach() {
               <legend className="mb-4 inline-block text-xl">
                 Filter by tag
               </legend>
-              {tags.map((tag: ICoachtag) => (
-                <CoachFilterTag
-                  disabled={!availableTagIDs.includes(tag.sys.id)}
-                  key={tag.sys.id}
-                  value={tag.fields.tag}
-                  name="tag"
-                  defaultValue={checkedTags.includes(tag.fields.tag)}
-                  type="checkbox"
-                >
-                  {tag.fields.tag}
-                </CoachFilterTag>
-              ))}
+              {tags.map((tag: ICoachtag) => {
+                const isNotSelectable =
+                  !availableTagIDs.includes(tag.sys.id) &&
+                  !checkedTags.includes(tag.fields.tag);
+                return (
+                  <CoachFilterTag
+                    disabled={isNotSelectable}
+                    key={tag.sys.id}
+                    value={tag.fields.tag}
+                    name="tag"
+                    defaultValue={checkedTags.includes(tag.fields.tag)}
+                    type="checkbox"
+                  >
+                    {tag.fields.tag}
+                  </CoachFilterTag>
+                );
+              })}
             </fieldset>
             <div className="flex items-center gap-4">
               <noscript>

--- a/app/routes/en.i-need-speaking-time.tsx
+++ b/app/routes/en.i-need-speaking-time.tsx
@@ -1,8 +1,9 @@
-import { ICoachtag } from "../../@types/generated/contentful";
-import { useLoaderData, useCatch, Form, useTransition } from "remix";
+import { useRef } from "react";
+import { useLoaderData, useCatch, Form, useTransition, useSubmit } from "remix";
 import type { LoaderFunction, MetaFunction } from "remix";
 import ContentBlocks from "~/components/ContentBlocks";
 import BasicLayout from "~/components/layout/BasicLayout";
+import { ICoachtag } from "../../@types/generated/contentful";
 import {
   getSearchPageContents,
   SearchPageContentResponse,
@@ -43,6 +44,15 @@ export default function SearchingCoach() {
     locale,
     availableTagIDs,
   } = useLoaderData();
+
+  const submit = useSubmit();
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const handleChange = () => {
+    if (formRef) {
+      submit(formRef.current, { replace: true });
+    }
+  };
   const state = useTransition();
   return (
     <BasicLayout nav={navigation.fields.items} lang={locale}>
@@ -52,7 +62,13 @@ export default function SearchingCoach() {
           <summary>
             <h5 className="inline-block text-xl">Show filters</h5>
           </summary>
-          <Form replace>
+          <Form
+            onChange={handleChange}
+            ref={formRef}
+            method="get"
+            id="filter-form"
+            className="flex flex-col gap-2"
+          >
             <fieldset className="mt-8">
               <legend className="mb-4 inline-block text-xl">
                 Filter by language
@@ -88,14 +104,16 @@ export default function SearchingCoach() {
               ))}
             </fieldset>
             <div className="flex items-center gap-4">
-              <button
-                className="font-inherit my-8 inline-flex items-center justify-center rounded-md bg-vsp-500 py-2 px-4 text-white no-underline transition-opacity duration-300 hover:opacity-90 focus:opacity-90 active:opacity-90 disabled:pointer-events-none disabled:bg-vsp-200 md:text-lg"
-                type="submit"
-                disabled={state.state === "submitting"}
-              >
-                Apply filter
-              </button>
-              <span className="text-sm text-slate-400">
+              <noscript>
+                <button
+                  className="font-inherit my-8 inline-flex items-center justify-center rounded-md bg-vsp-500 py-2 px-4 text-white no-underline transition-opacity duration-300 hover:opacity-90 focus:opacity-90 active:opacity-90 disabled:pointer-events-none disabled:bg-vsp-200 md:text-lg"
+                  type="submit"
+                  disabled={state.state === "submitting"}
+                >
+                  Apply filter
+                </button>
+              </noscript>
+              <span className="py-2 px-4 text-sm text-slate-400">
                 {coachesAmount} listeners found.
               </span>
             </div>

--- a/app/routes/en.i-need-speaking-time.tsx
+++ b/app/routes/en.i-need-speaking-time.tsx
@@ -88,7 +88,7 @@ export default function SearchingCoach() {
             </fieldset>
             <fieldset className="mt-8">
               <legend className="mb-4 inline-block text-xl">
-                Filter by tag
+                Filter by topic
               </legend>
               {tags.map((tag: ICoachtag) => {
                 const isNotSelectable =
@@ -119,7 +119,9 @@ export default function SearchingCoach() {
                 </button>
               </noscript>
               <span className="py-2 px-4 text-sm text-slate-400">
-                {coachesAmount} listeners found.
+                {coachesAmount
+                  ? `${coachesAmount} listeners found.`
+                  : `No listeners found for these filters :(`}
               </span>
             </div>
           </Form>

--- a/app/utils/getSearchPageContents.ts
+++ b/app/utils/getSearchPageContents.ts
@@ -75,7 +75,7 @@ export const getSearchPageContents = async (
   });
 
   // get available tags from all coaches
-  const availableTagIDs = filteredCoaches
+  const availableTagIDs = coaches
     .map((coach) => coach.fields.tag)
     .filter((tags) => !!tags)
     .map((tags) => tags.map((tag) => tag.sys.id))

--- a/app/utils/getSearchPageContents.ts
+++ b/app/utils/getSearchPageContents.ts
@@ -1,6 +1,5 @@
 import {
   ICoach,
-  ICoachList,
   ICoachtag,
   INavigation,
   IPage,


### PR DESCRIPTION
- Change the way we create `availableTagIDs`, as before all the tags will look deactivated if there are 0 results displayed. For example, if selecting these filters: ([Essstörung and EN](http://localhost:3000/de/ich-suche-redezeit?lang=en&tag=Essst%C3%B6rungen)) (test on a previous branch). Now, the user can still see which other tags are available and continue by clicking on those.

- Update UX text when no results are displayed and added logic.