### PR TITLE
(feat) Expand content blocks to display video

### DIFF
--- a/@types/generated/contentful.d.ts
+++ b/@types/generated/contentful.d.ts
@@ -22,6 +22,7 @@ export interface IBlogpostFields {
     | IContentWithFullSizeImage
     | ICenteredContent
     | ITwoImages
+    | IVideoPlayer
   )[];
 
   /** seo */

--- a/@types/generated/contentful.d.ts
+++ b/@types/generated/contentful.d.ts
@@ -562,6 +562,7 @@ export interface IPageFields {
     | IContentImageBg
     | IContentWithFullSizeImage
     | ICenteredContent
+    | IVideoPlayer
     | ITwoImages
   )[];
 
@@ -717,6 +718,36 @@ export interface ITwoImages extends Entry<ITwoImagesFields> {
   };
 }
 
+export interface IVideoPlayerFields {
+  /** videoID */
+  videoId: string;
+
+  /** title */
+  title?: string | undefined;
+
+  /** Content */
+  content?: Document | undefined;
+}
+
+/** Component to display videos */
+
+export interface IVideoPlayer extends Entry<IVideoPlayerFields> {
+  sys: {
+    id: string;
+    type: string;
+    createdAt: string;
+    updatedAt: string;
+    locale: string;
+    contentType: {
+      sys: {
+        id: "videoPlayer";
+        linkType: "ContentType";
+        type: "Link";
+      };
+    };
+  };
+}
+
 export type CONTENT_TYPE =
   | "blogpost"
   | "centeredContent"
@@ -738,7 +769,8 @@ export type CONTENT_TYPE =
   | "seo"
   | "supporter"
   | "tag"
-  | "twoImages";
+  | "twoImages"
+  | "videoPlayer";
 
 export type LOCALE_CODE = "de" | "en" | "ru" | "uk";
 

--- a/app/components/ContentBlocks.tsx
+++ b/app/components/ContentBlocks.tsx
@@ -8,6 +8,7 @@ import type {
   IImageCollectionFields,
   IPageFields,
   ITwoImagesFields,
+  IVideoPlayerFields,
   LOCALE_CODE,
 } from "../../@types/generated/contentful";
 import ContentBlockCentered from "./ContentBlocks/Centered";
@@ -116,8 +117,7 @@ export default function ContentBlocks({ content, locale }: ContentBlockProps) {
         }
 
         if (id === "videoPlayer") {
-          const { videoId, content } = item.fields;
-          console.log("video", videoId);
+          const { videoId, content } = item.fields as IVideoPlayerFields;
           return (
             <VideoPlayer
               key={item.sys.id}

--- a/app/components/ContentBlocks.tsx
+++ b/app/components/ContentBlocks.tsx
@@ -116,14 +116,13 @@ export default function ContentBlocks({ content, locale }: ContentBlockProps) {
         }
 
         if (id === "videoPlayer") {
-          const { videoId, title, content } = item.fields;
+          const { videoId, content } = item.fields;
           console.log("video", videoId);
           return (
             <VideoPlayer
               key={item.sys.id}
               videoId={videoId}
               content={content}
-              title={title}
             />
           );
         }

--- a/app/components/ContentBlocks.tsx
+++ b/app/components/ContentBlocks.tsx
@@ -17,6 +17,7 @@ import GenericContent from "./ContentBlocks/GenericContent";
 import ContentBlockHeader from "./ContentBlocks/Header";
 import ContentBlockImageBg from "./ContentBlocks/ImageBg";
 import ContentBlockTwoImages from "./ContentBlocks/TwoImages";
+import VideoPlayer from "./ContentBlocks/VideoPlayer";
 import ContentfulRichText from "./ContentfulRichText";
 
 type ContentBlockProps = {
@@ -48,6 +49,7 @@ export default function ContentBlocks({ content, locale }: ContentBlockProps) {
             />
           );
         }
+
         if (id === "centeredContent") {
           const { bgcolor, content, buttonText, buttonUrl } =
             item.fields as ICenteredContentFields;
@@ -112,6 +114,20 @@ export default function ContentBlocks({ content, locale }: ContentBlockProps) {
             />
           );
         }
+
+        if (id === "videoPlayer") {
+          const { videoId, title, content } = item.fields;
+          console.log("video", videoId);
+          return (
+            <VideoPlayer
+              key={item.sys.id}
+              videoId={videoId}
+              content={content}
+              title={title}
+            />
+          );
+        }
+
         if (id === "imageCollection") {
           const { internalTitle, images } =
             item.fields as IImageCollectionFields;
@@ -124,6 +140,7 @@ export default function ContentBlocks({ content, locale }: ContentBlockProps) {
             />
           );
         }
+
         if (id === "coachList") {
           return null;
         } else {

--- a/app/components/ContentBlocks/VideoPlayer.tsx
+++ b/app/components/ContentBlocks/VideoPlayer.tsx
@@ -1,0 +1,24 @@
+import ContentfulRichText from "../ContentfulRichText";
+
+export default function VideoPlayer({ videoId, text, content }) {
+  return (
+    <section className="grid w-screen max-w-full grid-cols-1 lg:grid-cols-2">
+      <div className="col-start-1 py-8 px-4 lg:row-start-1 lg:ml-auto lg:max-w-[70ch] lg:px-12 lg:pb-12 lg:pt-36">
+        {content && <ContentfulRichText content={content} />}
+      </div>
+      <div className="row-start-2 h-auto max-h-[60vh] w-full lg:col-start-2 lg:row-start-1 lg:max-h-max">
+        <iframe
+          width="100%"
+          height="100%"
+          src={`https://www.youtube.com/embed/${videoId}?rel=0&modestbranding=1&color=white`}
+          frameBorder="0"
+          allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          style={{
+            height: "400px",
+          }}
+        />
+      </div>
+    </section>
+  );
+}

--- a/app/components/ContentBlocks/VideoPlayer.tsx
+++ b/app/components/ContentBlocks/VideoPlayer.tsx
@@ -1,6 +1,6 @@
 import ContentfulRichText from "../ContentfulRichText";
 
-export default function VideoPlayer({ videoId, text, content }) {
+export default function VideoPlayer({ videoId, content }) {
   return (
     <section className="my-1 grid w-screen max-w-full grid-cols-1 lg:grid-cols-2">
       <div className=" flex-grid self-center py-8 px-4 lg:row-start-1 lg:ml-auto lg:max-w-[70ch] lg:px-12 lg:pt-24 lg:pb-12">

--- a/app/components/ContentBlocks/VideoPlayer.tsx
+++ b/app/components/ContentBlocks/VideoPlayer.tsx
@@ -1,6 +1,7 @@
+import { IVideoPlayerFields } from "../../../@types/generated/contentful";
 import ContentfulRichText from "../ContentfulRichText";
 
-export default function VideoPlayer({ videoId, content }) {
+export default function VideoPlayer({ videoId, content }: IVideoPlayerFields) {
   return (
     <section className="my-1 grid w-screen max-w-full grid-cols-1 lg:grid-cols-2">
       <div className=" flex-grid self-center py-8 px-4 lg:row-start-1 lg:ml-auto lg:max-w-[70ch] lg:px-12 lg:pt-24 lg:pb-12">

--- a/app/components/ContentBlocks/VideoPlayer.tsx
+++ b/app/components/ContentBlocks/VideoPlayer.tsx
@@ -2,11 +2,11 @@ import ContentfulRichText from "../ContentfulRichText";
 
 export default function VideoPlayer({ videoId, text, content }) {
   return (
-    <section className="grid w-screen max-w-full grid-cols-1 lg:grid-cols-2">
-      <div className="col-start-1 py-8 px-4 lg:row-start-1 lg:ml-auto lg:max-w-[70ch] lg:px-12 lg:pb-12 lg:pt-36">
+    <section className="my-1 grid w-screen max-w-full grid-cols-1 lg:grid-cols-2">
+      <div className=" flex-grid self-center py-8 px-4 lg:row-start-1 lg:ml-auto lg:max-w-[70ch] lg:px-12 lg:pt-24 lg:pb-12">
         {content && <ContentfulRichText content={content} />}
       </div>
-      <div className="row-start-2 h-auto max-h-[60vh] w-full lg:col-start-2 lg:row-start-1 lg:max-h-max">
+      <div className="row-start-2 h-auto max-h-[60vh] w-full lg:col-start-2 lg:row-start-1 lg:max-h-max lg:p-4">
         <iframe
           width="100%"
           height="100%"

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1483,6 +1483,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   border-width: 0;
 }
 
+.visible {
+  visibility: visible;
+}
+
 .fixed {
   position: fixed;
 }
@@ -1587,6 +1591,11 @@ Ensure the default browser behavior of the `hidden` attribute.
   margin-bottom: 2rem;
 }
 
+.my-0 {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
 .mr-8 {
   margin-right: 2rem;
 }
@@ -1679,6 +1688,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   height: 3rem;
 }
 
+.h-5 {
+  height: 1.25rem;
+}
+
 .max-h-40 {
   max-height: 10rem;
 }
@@ -1693,6 +1706,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .max-h-12 {
   max-height: 3rem;
+}
+
+.max-h-\[70vh\] {
+  max-height: 70vh;
 }
 
 .min-h-\[256px\] {
@@ -1741,6 +1758,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .w-12 {
   width: 3rem;
+}
+
+.w-5 {
+  width: 1.25rem;
 }
 
 .min-w-\[310px\] {
@@ -1851,6 +1872,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .grid-cols-coachgrid {
   grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+}
+
+.grid-cols-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
 .grid-rows-\[4rem_1fr\] {
@@ -2618,6 +2643,10 @@ Ensure the default browser behavior of the `hidden` attribute.
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
+  .md\:grid-cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
   .md\:flex-row {
     flex-direction: row;
   }
@@ -3094,8 +3123,28 @@ Ensure the default browser behavior of the `hidden` attribute.
     left: auto;
   }
 
+  .lg\:col-span-2 {
+    grid-column: span 2 / span 2;
+  }
+
+  .lg\:col-span-3 {
+    grid-column: span 3 / span 3;
+  }
+
+  .lg\:col-span-1 {
+    grid-column: span 1 / span 1;
+  }
+
   .lg\:col-start-2 {
     grid-column-start: 2;
+  }
+
+  .lg\:col-start-3 {
+    grid-column-start: 3;
+  }
+
+  .lg\:col-start-1 {
+    grid-column-start: 1;
   }
 
   .lg\:row-start-1 {
@@ -3104,6 +3153,10 @@ Ensure the default browser behavior of the `hidden` attribute.
 
   .lg\:mr-4 {
     margin-right: 1rem;
+  }
+
+  .lg\:ml-auto {
+    margin-left: auto;
   }
 
   .lg\:inline-block {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1519,6 +1519,10 @@ Ensure the default browser behavior of the `hidden` attribute.
   right: 0px;
 }
 
+.top-\[50\%\] {
+  top: 50%;
+}
+
 .z-50 {
   z-index: 50;
 }
@@ -1594,6 +1598,11 @@ Ensure the default browser behavior of the `hidden` attribute.
 .my-0 {
   margin-top: 0px;
   margin-bottom: 0px;
+}
+
+.my-1 {
+  margin-top: 0.25rem;
+  margin-bottom: 0.25rem;
 }
 
 .mr-8 {
@@ -1830,6 +1839,16 @@ Ensure the default browser behavior of the `hidden` attribute.
 
 .translate-x-\[90vw\] {
   --tw-translate-x: 90vw;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-y-\[50\%\] {
+  --tw-translate-y: 50%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.translate-y-\[-50\%\] {
+  --tw-translate-y: -50%;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -3159,6 +3178,10 @@ Ensure the default browser behavior of the `hidden` attribute.
     margin-left: auto;
   }
 
+  .lg\:mr-3 {
+    margin-right: 0.75rem;
+  }
+
   .lg\:inline-block {
     display: inline-block;
   }
@@ -3251,6 +3274,10 @@ Ensure the default browser behavior of the `hidden` attribute.
     background-color: transparent;
   }
 
+  .lg\:p-4 {
+    padding: 1rem;
+  }
+
   .lg\:py-1 {
     padding-top: 0.25rem;
     padding-bottom: 0.25rem;
@@ -3272,6 +3299,22 @@ Ensure the default browser behavior of the `hidden` attribute.
 
   .lg\:pt-36 {
     padding-top: 9rem;
+  }
+
+  .lg\:pt-28 {
+    padding-top: 7rem;
+  }
+
+  .lg\:pt-32 {
+    padding-top: 8rem;
+  }
+
+  .lg\:pt-20 {
+    padding-top: 5rem;
+  }
+
+  .lg\:pt-24 {
+    padding-top: 6rem;
   }
 
   .lg\:text-5xl {


### PR DESCRIPTION
Ticket: https://github.com/HerrBertling/virtualsupporttalks/issues/113

We want to be able to display videos on the website. In order to do that I have created a new component with a basic layout (text on the left, video on the right). We will relay on youtube for the video optimization, and just fetch the video from there using an iframe. The component can be extended in the future to support a different layout, or videos from vimeo.

There is also a new content type in contentful call VideoPlayer for this purpose, if we want to add more video on this format to other pages of the website.

### Missing steps
Generate new contentful types and add the missing types

Publish the changes on the [Tag des Zuhorens page](https://app.contentful.com/spaces/jz6x3ir73b58/entries/MNheKsLJ0r2uixEZhFaF1) to see the video displayed. 

### Demo
The demo linked below is recorded by pushing the Video component into the page components array through the code. We won't be able to access the video component in the stg environments yet (Is there a way to see nonpublished components in some environments, for this case?)

https://virtualsupporttalks.slack.com/files/U036U9DPPMK/F03RP2B1NCT/preview_video_component.mov