### PR TITLE
Fix error displaying video player on ipad

### DIFF
--- a/app/components/ContentBlocks/VideoPlayer.tsx
+++ b/app/components/ContentBlocks/VideoPlayer.tsx
@@ -3,11 +3,11 @@ import ContentfulRichText from "../ContentfulRichText";
 
 export default function VideoPlayer({ videoId, content }: IVideoPlayerFields) {
   return (
-    <section className="my-1 grid w-screen max-w-full grid-cols-1 lg:grid-cols-2">
-      <div className=" flex-grid self-center py-8 px-4 lg:row-start-1 lg:ml-auto lg:max-w-[70ch] lg:px-12 lg:pt-24 lg:pb-12">
+      <section className="mx-auto max-w-7xl grid w-screen grid-cols-1 gap-6 py-16 px-4 lg:grid-cols-2">
+      <div className="flex-grid self-center lg:row-start-1">
         {content && <ContentfulRichText content={content} />}
       </div>
-      <div className="row-start-2 h-auto w-full lg:col-start-2 lg:row-start-1 lg:max-h-max lg:p-4">
+      <div className="row-start-2 h-96 w-full lg:col-start-2 lg:row-start-1">
         <iframe
           width="100%"
           height="100%"
@@ -16,9 +16,7 @@ export default function VideoPlayer({ videoId, content }: IVideoPlayerFields) {
           allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
           style={{
-            width: "100%",
             aspectRatio: "16/9",
-            objectFit: "cover",
           }}
         />
       </div>

--- a/app/components/ContentBlocks/VideoPlayer.tsx
+++ b/app/components/ContentBlocks/VideoPlayer.tsx
@@ -7,7 +7,7 @@ export default function VideoPlayer({ videoId, content }: IVideoPlayerFields) {
       <div className="flex-grid self-center lg:row-start-1">
         {content && <ContentfulRichText content={content} />}
       </div>
-      <div className="row-start-2 h-96 w-full lg:col-start-2 lg:row-start-1">
+      <div className="row-start-2 h-96 w-full lg:col-start-2 lg:row-start-1"  style={{aspectRatio: "16/9"}}>
         <iframe
           width="100%"
           height="100%"
@@ -15,9 +15,6 @@ export default function VideoPlayer({ videoId, content }: IVideoPlayerFields) {
           frameBorder="0"
           allow="accelerometer; encrypted-media; gyroscope; picture-in-picture"
           allowFullScreen
-          style={{
-            aspectRatio: "16/9",
-          }}
         />
       </div>
     </section>


### PR DESCRIPTION
Still not sure why didn't work on iPad. I assign the `aspect-ratio` to the container and now it works (the tailwind helper didn't work for some reason, so I added it as a style directly). I also cleaned up a bit so the spacing happens on the container instead of in the children.

Ideally, we would also `self-align:center` it but when doing that, it's displayed with the incorrect height (kind of cut)

It works for me on a real device and BrowserStack simulator:
![IMG_0009](https://user-images.githubusercontent.com/88032788/195181089-39194b01-e5b2-4104-bbec-a7b6e90335d6.PNG)

(Ignore the square on the top right - my partner was watching something in the background when I asked him to test 😂 )