### PR TITLE
add default 'de' flag only if no languages are provided

### DIFF
--- a/app/utils/getFlagCodes.ts
+++ b/app/utils/getFlagCodes.ts
@@ -12,12 +12,14 @@ export default function getFlagCode(languages: string[] | undefined) {
     ru: "RU",
     ukr: "UA",
   };
-  const result = ["DE"];
+  const result: string[] = [];
 
-  languages &&
-    languages.forEach((lang) => {
-      result.push(flagCodes[lang as keyof typeof flagCodes]);
-    });
+  languages
+    ? languages.forEach((lang) => {
+        result.push(flagCodes[lang as keyof typeof flagCodes]);
+      })
+    : result.push("DE");
 
+  console.log(languages, [...new Set(result)]);
   return [...new Set(result)];
 }

--- a/app/utils/getFlagCodes.ts
+++ b/app/utils/getFlagCodes.ts
@@ -20,6 +20,5 @@ export default function getFlagCode(languages: string[] | undefined) {
       })
     : result.push("DE");
 
-  console.log(languages, [...new Set(result)]);
   return [...new Set(result)];
 }


### PR DESCRIPTION
> From Flo: I noticed that some of the Ukrainian and Russian listeners do not explicitly speak German but the flag shows up. 

To know: not all coaches have added the language tags, so we will default to german only if no languages are provided.
Edge case to consider: it could be that some coaches have the tag only referring to the ""extra"" language they speak, assuming that german is the default one. In that case, only the extra languages will appear in the flag component. This could easily be changed in contentful if it becomes a problem.