### PR TITLE
Fix display german flag

### DIFF
--- a/app/components/SpeakingTimeContent.tsx
+++ b/app/components/SpeakingTimeContent.tsx
@@ -142,14 +142,12 @@ export default function SpeakingTimeContent({
                 {t("filter.submitCta")}
               </button>
             </noscript>
-            <span className="py-2 px-4 text-sm text-slate-400">
-              {coachesAmount
-                ? `${coachesAmount} ${t("result")}`
-                : t("noResult")}
-            </span>
           </div>
         </Form>
       </details>
+      <div className="text-m mx-auto max-w-7xl py-4 px-4 font-semibold text-slate-700">
+        {coachesAmount ? `${coachesAmount} ${t("result")}` : t("noResult")}
+      </div>
       <CoachList coaches={coaches} />
     </div>
   );

--- a/app/utils/getFlagCodes.ts
+++ b/app/utils/getFlagCodes.ts
@@ -18,7 +18,7 @@ export default function getFlagCode(languages: string[] | undefined) {
     ? languages.forEach((lang) => {
         result.push(flagCodes[lang as keyof typeof flagCodes]);
       })
-    : ["DE"];
+    : result.push("DE");
 
   return [...new Set(result)];
 }


### PR DESCRIPTION
Fix display german flag && displaying the message more prominent so that the user sees a bit better that they need to update the filter selection to get a result (it's not the master solution, but maybe it helps in some cases, we might need to check the filter behavior all together)

Ready for merging if approved :)

Flag emojis not displaying on windows is a general thing and they do it because of political issues. We can add them as .svg in another iteration