### PR TITLE
feat(caching): reduce Netlify function invocations via durable CDN + tag purge

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,0 +1,22 @@
+# Contentful Delivery API
+CONTENTFUL_SPACE=
+CONTENTFUL_ACCESSTOKEN=
+CONTENTFUL_ENVIRONMENT=master
+CONTENTFUL_MANAGEMENT_API_ACCESS_TOKEN=
+
+# Analytics / email
+VITE_GTM_ID=
+VITE_GA_ID=
+VITE_BREVO_KEY=
+
+# Admin CSV export
+CSV_DOWNLOAD_PW=
+
+# Cache purge webhook (POST /api/revalidate from Contentful)
+# - CONTENTFUL_WEBHOOK_SECRET: value must match the X-Webhook-Secret header
+#   configured on the Contentful webhook
+# - NETLIFY_SITE_ID: Netlify site ID (API ID, not site name)
+# - NETLIFY_PURGE_TOKEN: Netlify Personal Access Token with purge permission
+CONTENTFUL_WEBHOOK_SECRET=
+NETLIFY_SITE_ID=
+NETLIFY_PURGE_TOKEN=

--- a/app/routes/$locale.$slug.tsx
+++ b/app/routes/$locale.$slug.tsx
@@ -1,6 +1,8 @@
+import { data } from "react-router";
 import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import ContentBlocks from "~/components/ContentBlocks";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getLatestBlogposts, getPage } from "~/utils/contentful";
 import type { IBlogpost, LOCALE_CODE } from "../../types/contentful";
 import type { Route } from "./+types/$locale.$slug";
@@ -42,7 +44,18 @@ export async function loader({ params }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  return { page, locale: locale as LOCALE_CODE, latestPosts };
+  return data(
+    { page, locale: locale as LOCALE_CODE, latestPosts },
+    {
+      headers: {
+        "Cache-Tag": `entry:${page.sys.id},collection:blogpost,nav:${locale}`,
+      },
+    }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function Index({ loaderData }: Route.ComponentProps) {

--- a/app/routes/$locale._index.tsx
+++ b/app/routes/$locale._index.tsx
@@ -1,5 +1,7 @@
+import { data } from "react-router";
 import ContentBlocks from "~/components/ContentBlocks";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getLatestBlogposts, getPageById } from "~/utils/contentful";
 import pageIds from "~/utils/pageIds";
 import type { IBlogpost, LOCALE_CODE } from "../../types/contentful";
@@ -38,7 +40,18 @@ export async function loader({ params }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  return { page, locale, latestPosts };
+  return data(
+    { page, locale, latestPosts },
+    {
+      headers: {
+        "Cache-Tag": `entry:${page.sys.id},collection:blogpost,nav:${locale}`,
+      },
+    }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function Index({ loaderData }: Route.ComponentProps) {

--- a/app/routes/$locale.blog.$post.tsx
+++ b/app/routes/$locale.blog.$post.tsx
@@ -1,7 +1,9 @@
+import { data } from "react-router";
 import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import ContentBlocks from "~/components/ContentBlocks";
 import TagGroup from "~/components/TagGroup";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getBlogpost } from "~/utils/contentful";
 import { ensureFound } from "~/utils/ensureFound";
 import type { LOCALE_CODE } from "../../types/contentful";
@@ -28,12 +30,6 @@ export const meta: Route.MetaFunction = ({ data }) => {
   ];
 };
 
-export function headers() {
-  return {
-    "Cache-Control": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400",
-  };
-}
-
 export async function loader({ params }: Route.LoaderArgs) {
   const { post, locale } = params;
 
@@ -46,7 +42,18 @@ export async function loader({ params }: Route.LoaderArgs) {
     "Blog post not found"
   );
 
-  return { blogpost, locale: locale as LOCALE_CODE };
+  return data(
+    { blogpost, locale: locale as LOCALE_CODE },
+    {
+      headers: {
+        "Cache-Tag": `entry:${blogpost.sys.id},collection:blogpost,nav:${locale}`,
+      },
+    }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function Blogpost({ loaderData }: Route.ComponentProps) {

--- a/app/routes/$locale.blog._index.tsx
+++ b/app/routes/$locale.blog._index.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from "react-i18next";
+import { data } from "react-router";
 import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import BlogpostCard from "~/components/BlogpostCard";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getBlogposts } from "~/utils/contentful";
 import type { IBlogpost, LOCALE_CODE } from "../../types/contentful";
 import type { Route } from "./+types/$locale.blog._index";
@@ -13,7 +15,11 @@ export async function loader({ params }: Route.LoaderArgs) {
     throw new Response("Not Found", { status: 404 });
   }
 
-  return { posts, locale };
+  return data({ posts, locale }, { headers: { "Cache-Tag": `collection:blogpost,nav:${locale}` } });
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function Index({ loaderData }: Route.ComponentProps) {

--- a/app/routes/$locale.blog.tag.$tag.tsx
+++ b/app/routes/$locale.blog.tag.$tag.tsx
@@ -1,6 +1,8 @@
 import { useTranslation } from "react-i18next";
+import { data } from "react-router";
 import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import BlogpostCard from "~/components/BlogpostCard";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getBlogposts } from "~/utils/contentful";
 import type { IBlogpost, LOCALE_CODE } from "../../types/contentful";
 import type { Route } from "./+types/$locale.blog.tag.$tag";
@@ -38,7 +40,14 @@ export async function loader({ params }: Route.LoaderArgs) {
     });
   }
 
-  return { posts: postsWithCurrentTag, locale, tag };
+  return data(
+    { posts: postsWithCurrentTag, locale, tag },
+    { headers: { "Cache-Tag": `collection:blogpost,nav:${locale}` } }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function Index({ loaderData }: Route.ComponentProps) {

--- a/app/routes/$locale.sitemap[.]xml.tsx
+++ b/app/routes/$locale.sitemap[.]xml.tsx
@@ -40,7 +40,9 @@ export async function loader(_args: Route.LoaderArgs) {
   const headers: HeadersInit = {
     "Content-Type": "application/xml; charset=utf-8",
     "x-content-type-options": "nosniff",
-    "Cache-Control": "public, max-age=3600, s-maxage=86400",
+    "Cache-Control": "public, max-age=0, must-revalidate",
+    "Netlify-CDN-Cache-Control": "public, s-maxage=86400, stale-while-revalidate=604800, durable",
+    "Cache-Tag": "collection:page",
   };
 
   return new Response(xml.join(""), { headers });

--- a/app/routes/$locale.tsx
+++ b/app/routes/$locale.tsx
@@ -9,8 +9,14 @@ import type { Route } from "./+types/$locale";
 export async function loader({ params }: Route.LoaderArgs) {
   const locale = (params.locale as LOCALE_CODE) || "de";
   if (!availableLocales.includes(locale)) {
-    console.warn("REDIRECTING FROM LOCALE FILE BECAUSE THE LOCALE IS:", locale);
-    throw redirect(`/de/${locale}`, 301);
+    // Only treat the param as a typo'd locale if it actually looks like
+    // a locale code (two letters, optional region). Everything else —
+    // /robots.txt, /favicon.ico, /api, reserved paths — 404s so it
+    // doesn't pollute /de/<anything> with bogus redirects.
+    if (/^[a-z]{2}(-[a-z]{2})?$/i.test(locale)) {
+      throw redirect(`/de/${locale}`, 301);
+    }
+    throw new Response("Not Found", { status: 404 });
   }
 
   const navObject = await getMainNav(locale);

--- a/app/routes/api.revalidate.tsx
+++ b/app/routes/api.revalidate.tsx
@@ -1,0 +1,77 @@
+import type { Route } from "./+types/api.revalidate";
+
+type ContentfulSysLink = { sys: { id: string } };
+type ContentfulWebhookPayload = {
+  sys?: {
+    id?: string;
+    contentType?: ContentfulSysLink;
+  };
+};
+
+const NO_STORE = {
+  "Cache-Control": "private, no-store",
+  "Netlify-CDN-Cache-Control": "private, no-store",
+};
+
+export function loader() {
+  return new Response("Method not allowed", { status: 405, headers: NO_STORE });
+}
+
+export async function action({ request }: Route.ActionArgs) {
+  if (request.method !== "POST") {
+    return new Response("Method not allowed", { status: 405, headers: NO_STORE });
+  }
+
+  const secret = process.env.CONTENTFUL_WEBHOOK_SECRET;
+  const siteId = process.env.NETLIFY_SITE_ID;
+  const token = process.env.NETLIFY_PURGE_TOKEN;
+
+  if (!secret || !siteId || !token) {
+    return new Response("Purge endpoint not configured", {
+      status: 500,
+      headers: NO_STORE,
+    });
+  }
+
+  if (request.headers.get("X-Webhook-Secret") !== secret) {
+    return new Response("Unauthorized", { status: 401, headers: NO_STORE });
+  }
+
+  const payload = (await request.json().catch(() => null)) as ContentfulWebhookPayload | null;
+  const entryId = payload?.sys?.id;
+  const contentType = payload?.sys?.contentType?.sys?.id;
+
+  if (!entryId) {
+    return new Response("Payload missing sys.id", { status: 400, headers: NO_STORE });
+  }
+
+  const tags = [`entry:${entryId}`];
+  if (contentType) {
+    tags.push(`collection:${contentType}`);
+    if (contentType === "navigation") {
+      tags.push("nav:de", "nav:en", "nav:ru", "nav:uk");
+    }
+  }
+
+  const purgeResponse = await fetch("https://api.netlify.com/api/v1/purge", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ site_id: siteId, cache_tags: tags }),
+  });
+
+  if (!purgeResponse.ok) {
+    const detail = await purgeResponse.text().catch(() => "");
+    return new Response(`Netlify purge failed: ${purgeResponse.status} ${detail}`, {
+      status: 502,
+      headers: NO_STORE,
+    });
+  }
+
+  return new Response(JSON.stringify({ purged: tags }), {
+    status: 200,
+    headers: { "Content-Type": "application/json", ...NO_STORE },
+  });
+}

--- a/app/routes/api.revalidate.tsx
+++ b/app/routes/api.revalidate.tsx
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from "node:crypto";
 import type { Route } from "./+types/api.revalidate";
 
 type ContentfulSysLink = { sys: { id: string } };
@@ -33,7 +34,9 @@ export async function action({ request }: Route.ActionArgs) {
     });
   }
 
-  if (request.headers.get("X-Webhook-Secret") !== secret) {
+  const given = Buffer.from(request.headers.get("X-Webhook-Secret") ?? "");
+  const expected = Buffer.from(secret);
+  if (given.length !== expected.length || !timingSafeEqual(given, expected)) {
     return new Response("Unauthorized", { status: 401, headers: NO_STORE });
   }
 
@@ -64,10 +67,8 @@ export async function action({ request }: Route.ActionArgs) {
 
   if (!purgeResponse.ok) {
     const detail = await purgeResponse.text().catch(() => "");
-    return new Response(`Netlify purge failed: ${purgeResponse.status} ${detail}`, {
-      status: 502,
-      headers: NO_STORE,
-    });
+    console.error("Netlify purge failed", purgeResponse.status, detail);
+    return new Response("Purge failed", { status: 502, headers: NO_STORE });
   }
 
   return new Response(JSON.stringify({ purged: tags }), {

--- a/app/routes/de.ich-suche-redezeit.tsx
+++ b/app/routes/de.ich-suche-redezeit.tsx
@@ -2,12 +2,16 @@ import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import BasicLayout from "~/components/layout/BasicLayout";
 import SpeakingTimeContent from "~/components/SpeakingTimeContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getSearchPageContents } from "~/utils/getSearchPageContents";
 import type { Route } from "./+types/de.ich-suche-redezeit";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const data = await getSearchPageContents(request, "de");
-  return data;
+  return getSearchPageContents(request, "de");
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export const meta: Route.MetaFunction = ({ data }) => {

--- a/app/routes/de.netzwerk-partner-medien.tsx
+++ b/app/routes/de.netzwerk-partner-medien.tsx
@@ -1,5 +1,7 @@
+import { data } from "react-router";
 import NetworkPartnerMediaContent from "~/components/NetworkPartnerMediaContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getMainNav, getMedia, getNetwork, getPageById, getSupporters } from "~/utils/contentful";
 import { ensureFound } from "~/utils/ensureFound";
 import pageIds from "~/utils/pageIds";
@@ -40,14 +42,27 @@ export async function loader() {
     (item): item is NonNullable<typeof item> => item !== undefined
   );
 
-  return {
-    page: ensureFound(page, "Could not load page"),
-    navItems,
-    network: network ?? [],
-    supporters: supporters ?? [],
-    media: media ?? [],
-    locale,
-  };
+  const validPage = ensureFound(page, "Could not load page");
+
+  return data(
+    {
+      page: validPage,
+      navItems,
+      network: network ?? [],
+      supporters: supporters ?? [],
+      media: media ?? [],
+      locale,
+    },
+    {
+      headers: {
+        "Cache-Tag": `entry:${validPage.sys.id},collection:network,collection:supporter,collection:media,nav:${locale}`,
+      },
+    }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function SupportMedia({ loaderData }: Route.ComponentProps) {

--- a/app/routes/en.i-need-speaking-time.tsx
+++ b/app/routes/en.i-need-speaking-time.tsx
@@ -2,12 +2,16 @@ import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import BasicLayout from "~/components/layout/BasicLayout";
 import SpeakingTimeContent from "~/components/SpeakingTimeContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getSearchPageContents } from "~/utils/getSearchPageContents";
 import type { Route } from "./+types/en.i-need-speaking-time";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const data = await getSearchPageContents(request, "en");
-  return data;
+  return getSearchPageContents(request, "en");
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export const meta: Route.MetaFunction = ({ data }) => {

--- a/app/routes/en.network-partner-media.tsx
+++ b/app/routes/en.network-partner-media.tsx
@@ -1,5 +1,7 @@
+import { data } from "react-router";
 import NetworkPartnerMediaContent from "~/components/NetworkPartnerMediaContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getMainNav, getMedia, getNetwork, getPageById, getSupporters } from "~/utils/contentful";
 import { ensureFound } from "~/utils/ensureFound";
 import pageIds from "~/utils/pageIds";
@@ -40,14 +42,27 @@ export async function loader() {
     (item): item is NonNullable<typeof item> => item !== undefined
   );
 
-  return {
-    page: ensureFound(page, "Could not load page"),
-    navItems,
-    network: network ?? [],
-    supporters: supporters ?? [],
-    media: media ?? [],
-    locale,
-  };
+  const validPage = ensureFound(page, "Could not load page");
+
+  return data(
+    {
+      page: validPage,
+      navItems,
+      network: network ?? [],
+      supporters: supporters ?? [],
+      media: media ?? [],
+      locale,
+    },
+    {
+      headers: {
+        "Cache-Tag": `entry:${validPage.sys.id},collection:network,collection:supporter,collection:media,nav:${locale}`,
+      },
+    }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function SupportMedia({ loaderData }: Route.ComponentProps) {

--- a/app/routes/ru.i-need-speaking-time.tsx
+++ b/app/routes/ru.i-need-speaking-time.tsx
@@ -2,12 +2,16 @@ import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import BasicLayout from "~/components/layout/BasicLayout";
 import SpeakingTimeContent from "~/components/SpeakingTimeContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getSearchPageContents } from "~/utils/getSearchPageContents";
 import type { Route } from "./+types/ru.i-need-speaking-time";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const data = await getSearchPageContents(request, "ru");
-  return data;
+  return getSearchPageContents(request, "ru");
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export const meta: Route.MetaFunction = ({ data }) => {

--- a/app/routes/ru.network-partner-media.tsx
+++ b/app/routes/ru.network-partner-media.tsx
@@ -1,5 +1,7 @@
+import { data } from "react-router";
 import NetworkPartnerMediaContent from "~/components/NetworkPartnerMediaContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getMainNav, getMedia, getNetwork, getPageById, getSupporters } from "~/utils/contentful";
 import { ensureFound } from "~/utils/ensureFound";
 import pageIds from "~/utils/pageIds";
@@ -40,14 +42,27 @@ export async function loader() {
     (item): item is NonNullable<typeof item> => item !== undefined
   );
 
-  return {
-    page: ensureFound(page, "Could not load page"),
-    navItems,
-    network: network ?? [],
-    supporters: supporters ?? [],
-    media: media ?? [],
-    locale,
-  };
+  const validPage = ensureFound(page, "Could not load page");
+
+  return data(
+    {
+      page: validPage,
+      navItems,
+      network: network ?? [],
+      supporters: supporters ?? [],
+      media: media ?? [],
+      locale,
+    },
+    {
+      headers: {
+        "Cache-Tag": `entry:${validPage.sys.id},collection:network,collection:supporter,collection:media,nav:${locale}`,
+      },
+    }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function SupportMedia({ loaderData }: Route.ComponentProps) {

--- a/app/routes/uk.i-need-speaking-time.tsx
+++ b/app/routes/uk.i-need-speaking-time.tsx
@@ -2,12 +2,16 @@ import BasicCatchBoundary from "~/components/BasicErrorBoundary";
 import BasicLayout from "~/components/layout/BasicLayout";
 import SpeakingTimeContent from "~/components/SpeakingTimeContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getSearchPageContents } from "~/utils/getSearchPageContents";
 import type { Route } from "./+types/uk.i-need-speaking-time";
 
 export async function loader({ request }: Route.LoaderArgs) {
-  const data = await getSearchPageContents(request, "uk");
-  return data;
+  return getSearchPageContents(request, "uk");
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export const meta: Route.MetaFunction = ({ data }) => {

--- a/app/routes/uk.network-partner-media.tsx
+++ b/app/routes/uk.network-partner-media.tsx
@@ -1,5 +1,7 @@
+import { data } from "react-router";
 import NetworkPartnerMediaContent from "~/components/NetworkPartnerMediaContent";
 import { getSeoMeta } from "~/seo";
+import { publicCacheHeaders } from "~/utils/cacheHeaders";
 import { getMainNav, getMedia, getNetwork, getPageById, getSupporters } from "~/utils/contentful";
 import { ensureFound } from "~/utils/ensureFound";
 import pageIds from "~/utils/pageIds";
@@ -40,14 +42,27 @@ export async function loader() {
     (item): item is NonNullable<typeof item> => item !== undefined
   );
 
-  return {
-    page: ensureFound(page, "Could not load page"),
-    navItems,
-    network: network ?? [],
-    supporters: supporters ?? [],
-    media: media ?? [],
-    locale,
-  };
+  const validPage = ensureFound(page, "Could not load page");
+
+  return data(
+    {
+      page: validPage,
+      navItems,
+      network: network ?? [],
+      supporters: supporters ?? [],
+      media: media ?? [],
+      locale,
+    },
+    {
+      headers: {
+        "Cache-Tag": `entry:${validPage.sys.id},collection:network,collection:supporter,collection:media,nav:${locale}`,
+      },
+    }
+  );
+}
+
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
+  return publicCacheHeaders(loaderHeaders);
 }
 
 export default function SupportMedia({ loaderData }: Route.ComponentProps) {

--- a/app/utils/cacheHeaders.ts
+++ b/app/utils/cacheHeaders.ts
@@ -1,0 +1,11 @@
+const BROWSER_CACHE = "public, max-age=0, must-revalidate";
+const CDN_CACHE = "public, s-maxage=3600, stale-while-revalidate=604800, durable";
+
+export function publicCacheHeaders(loaderHeaders: Headers) {
+  const tag = loaderHeaders.get("Cache-Tag");
+  return {
+    "Cache-Control": BROWSER_CACHE,
+    "Netlify-CDN-Cache-Control": CDN_CACHE,
+    ...(tag ? { "Cache-Tag": tag } : {}),
+  };
+}

--- a/app/utils/getSearchPageContents.ts
+++ b/app/utils/getSearchPageContents.ts
@@ -1,3 +1,4 @@
+import { data } from "react-router";
 import {
   extractGender,
   extractLanguages,
@@ -52,19 +53,26 @@ export const getSearchPageContents = async (request: Request, locale: LOCALE_COD
 
   const availableTagIDs = getAvailableTagIDs(filteredCoaches);
 
-  return {
-    page: validPage,
-    coaches: filteredCoaches,
-    languages,
-    gender,
-    tags: tags ?? [],
-    navItems,
-    checkedTags,
-    checkedGender,
-    locale,
-    currentLang: lang,
-    coachesAmount: filteredCoaches?.length || 0,
-    availableTagIDs,
-    emailTemplate,
-  };
+  return data(
+    {
+      page: validPage,
+      coaches: filteredCoaches,
+      languages,
+      gender,
+      tags: tags ?? [],
+      navItems,
+      checkedTags,
+      checkedGender,
+      locale,
+      currentLang: lang,
+      coachesAmount: filteredCoaches?.length || 0,
+      availableTagIDs,
+      emailTemplate,
+    },
+    {
+      headers: {
+        "Cache-Tag": `entry:${validPage.sys.id},collection:coach,collection:coachtag,nav:${locale}`,
+      },
+    }
+  );
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -31,3 +31,19 @@ for = "/api/*"
 [headers.values]
   "Cache-Control" = "private, no-store"
   "Netlify-CDN-Cache-Control" = "private, no-store"
+
+# Password-gated admin routes return coach PII on POST. POST is uncacheable
+# per HTTP spec, but pin it explicitly so the form GET and any future loader
+# response can't land in the durable CDN either.
+[[headers]]
+for = "/*/admin/*"
+[headers.values]
+  "Cache-Control" = "private, no-store"
+  "Netlify-CDN-Cache-Control" = "private, no-store"
+
+# Sets the gdprConsent cookie on POST. Never cache.
+[[headers]]
+for = "/enable-analytics"
+[headers.values]
+  "Cache-Control" = "private, no-store"
+  "Netlify-CDN-Cache-Control" = "private, no-store"

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,4 +21,5 @@ for = "/fonts/*"
 [[headers]]
 for = "/*"
 [headers.values]
-  "Cache-Control" = "public, max-age=300, s-maxage=3600"
+  "Cache-Control" = "public, max-age=0, must-revalidate"
+  "Netlify-CDN-Cache-Control" = "public, s-maxage=3600, stale-while-revalidate=604800, durable"

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,3 +23,11 @@ for = "/*"
 [headers.values]
   "Cache-Control" = "public, max-age=0, must-revalidate"
   "Netlify-CDN-Cache-Control" = "public, s-maxage=3600, stale-while-revalidate=604800, durable"
+
+# API endpoints must never be CDN-cached. The global /* rule would otherwise
+# let stale 301s or other pre-deploy responses pin here for the SWR window.
+[[headers]]
+for = "/api/*"
+[headers.values]
+  "Cache-Control" = "private, no-store"
+  "Netlify-CDN-Cache-Control" = "private, no-store"


### PR DESCRIPTION
## Summary

Three-layer caching strategy to cut Netlify function invocations (overage-cost driver) while preserving editorial freshness via Contentful webhooks.

- **Layer 1 — Durable CDN cache + SWR** (`netlify.toml`): global `/*` switched to `Netlify-CDN-Cache-Control: public, s-maxage=3600, stale-while-revalidate=604800, durable` plus browser-scoped `max-age=0, must-revalidate`. `durable` persists CDN cache across deploys; SWR serves stale instantly while a single background revalidation refreshes each URL.
- **Layer 2 — Per-route `Cache-Tag` headers**: every public loader now emits `Cache-Tag` listing the Contentful entry IDs and content-type collections it depends on. New `publicCacheHeaders` helper forwards the tag alongside the durable CDN policy. Touched: homepage, generic `/[locale]/[slug]`, blog index/post/tag, coach search (4 locales), network pages (4 locales), sitemap.
- **Layer 3 — Purge webhook** (`POST /api/revalidate`): verifies `X-Webhook-Secret`, calls Netlify's purge API with `entry:<id>` and `collection:<contentType>` tags. Navigation entries additionally purge `nav:<locale>` for all four locales.

**Bonus fixes (found during testing):**

- `netlify.toml` adds `/api/*` override to force `private, no-store` — prevents API responses from ever being CDN-cached (protects against a stale 301 pinning for the SWR window).
- `$locale.tsx` no longer catch-all-redirects every top-level path to `/de/<path>`. It now 404s for non-locale-shaped params, which fixes `/robots.txt`, `/favicon.ico`, and similar that were previously 301ing to `/de/robots.txt` on prod (visible in the function logs). Typo-tolerance redirects still apply for actual locale-shape strings (`/fr` → `/de/fr`).

Routes with actions/cookies deliberately skipped (`enable-analytics.tsx`, `$locale.admin.csv-export.tsx`).

## End-to-end verification (on preview)

- Homepage served from durable CDN cache (`Netlify Durable; hit`), no function call.
- `Cache-Tag` headers present on all targeted routes with correct entry IDs + collections.
- Coach publish → Contentful webhook → `POST /api/revalidate` → Netlify purge API → 200, `{"purged":["entry:<id>","collection:coach"]}`.
- Coach search pages (all 4 locales) invalidated and re-stored; homepage and blog (mismatching tags) untouched.

## Before enabling in production

1. Add to Netlify **Production** env: `CONTENTFUL_WEBHOOK_SECRET`, `NETLIFY_SITE_ID`, `NETLIFY_PURGE_TOKEN`.
2. Point Contentful webhook URL at `https://www.virtualsupporttalks.de/api/revalidate` (currently set to the preview URL for testing).
3. Monitor Netlify Analytics → Functions for 48 h post-merge — expect a significant invocation-count drop once the cache warms.

## Test plan

- [x] `curl -I <preview>/de` shows `Netlify-Durable hit` on second request
- [x] `Cache-Tag` header present on all public routes
- [x] Coach publish triggers surgical purge (coach pages only, not homepage)
- [x] Webhook activity log shows 200 with `{"purged":[...]}`
- [ ] Post-merge: monitor function invocation count for 48 h

🤖 Generated with [Claude Code](https://claude.com/claude-code)