### PR TITLE
fix(nav): always prefix locale for url-based nav items

### DIFF
--- a/app/components/layout/Footer.tsx
+++ b/app/components/layout/Footer.tsx
@@ -9,7 +9,7 @@ type FooterNavLink = {
 const footerNav: FooterNavLink[] = [
   {
     link: {
-      de: "/impressum/",
+      de: "/de/impressum/",
       en: "/en/imprint/",
       ru: "/ru/imprint/",
       uk: "/uk/imprint/",
@@ -23,7 +23,7 @@ const footerNav: FooterNavLink[] = [
   },
   {
     link: {
-      de: "/datenschutz/",
+      de: "/de/datenschutz/",
       en: "/en/privacy/",
       ru: "/ru/privacy/",
       uk: "/uk/privacy/",

--- a/app/components/layout/Navigation.tsx
+++ b/app/components/layout/Navigation.tsx
@@ -19,7 +19,7 @@ export default function Navigation({ nav, lang }: { nav: INavigationItem[]; lang
       }
       if (page?.fields?.slug) {
         path = `/${lang}/${page.fields.slug}`;
-      } else if (lang !== "de") {
+      } else if (path.startsWith("/")) {
         path = `/${lang}${path}`;
       }
       return {


### PR DESCRIPTION
## Summary

- URL-based nav items (e.g. the Blog entry pointing at `/blog`) only landed on the right route for DE because the old `$locale.tsx` catch-all 301'd `/blog` → `/de/blog`.
- #364 removed that catch-all (intentionally — it was also 301'ing `/robots.txt`, `/favicon.ico`, etc.), so `/blog` now 404s on DE.
- Build the locale-prefixed path up front on all locales whenever the resolved path is site-relative. External URLs (anything not starting with `/`) are left untouched.

## Test plan

- [ ] `/` on DE → Blog nav link points to `/de/blog`, resolves
- [ ] `/en` → `/en/blog`, resolves
- [ ] External links in nav (if any) unchanged
- [ ] Page-backed nav items (with `page.fields.slug`) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)