### PR TITLE
perf(nav): prefetch header nav links and cache prefetched data

### DIFF
--- a/app/components/layout/NavItem.tsx
+++ b/app/components/layout/NavItem.tsx
@@ -17,6 +17,7 @@ export default function NavItem({ to, children }: NavItemProps) {
           }`
         }
         to={to}
+        prefetch="intent"
       >
         {children}
       </NavLink>

--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -10,6 +10,20 @@ import { getInstance } from "./middleware/i18next";
 
 export const streamTimeout = 5_000;
 
+export function handleDataRequest(response: Response, { request }: { request: Request }) {
+  if (request.method !== "GET") return response;
+  const isPrefetch =
+    request.headers.get("Purpose") === "prefetch" ||
+    request.headers.get("X-Purpose") === "prefetch" ||
+    request.headers.get("Sec-Purpose") === "prefetch" ||
+    request.headers.get("Sec-Fetch-Purpose") === "prefetch" ||
+    request.headers.get("X-Moz") === "prefetch";
+  if (isPrefetch) {
+    response.headers.set("Cache-Control", "private, max-age=10");
+  }
+  return response;
+}
+
 export default async function handleRequest(
   request: Request,
   responseStatusCode: number,


### PR DESCRIPTION
## Summary
- Enable `prefetch="intent"` on the primary header nav so loader data + route code are fetched on hover/focus.
- Add `handleDataRequest` in `entry.server.tsx` that overrides `Cache-Control` to `private, max-age=10` **only** for prefetch data requests (detects `Purpose`, `X-Purpose`, `Sec-Purpose`, `Sec-Fetch-Purpose`, `X-Moz`). Normal navigations keep the existing `publicCacheHeaders` policy.
- Fixes the classic Remix double-data-request-on-prefetch ([background](https://sergiodxa.com/tutorials/fix-double-data-request-when-prefetching-in-remix)): without a browser-cacheable response, the prefetched `.data` request is re-issued on click.

## Test plan
- [x] `npm run typecheck` passes locally (verified)
- [ ] Open devtools → Network, hover a header nav link: `.data` request lands with `Cache-Control: private, max-age=10`
- [ ] Click that nav link within ~10s: no second `.data` request is made
- [ ] Direct navigation (typing URL / external link) still returns the normal `publicCacheHeaders` response
- [ ] Sanity check across locales (`/de`, `/en`, `/ru`, `/uk`) and that blog / slug / language-specific routes all behave

🤖 Generated with [Claude Code](https://claude.com/claude-code)