### PR TITLE
ci: add lint+typecheck+test workflow + format drift fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run lint
+
+      - run: npm run typecheck
+
+      - run: npm test -- --run

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { Link } from "react-router";
-import { useOnClickOutside } from "usehooks-ts";
 import type { LOCALE_CODE } from "types/contentful";
+import { useOnClickOutside } from "usehooks-ts";
 import { availableLocales } from "~/utils/locales";
 import GlobeAltIcon from "./icons/GlobeAltIcon";
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -29,8 +29,20 @@ export const meta: MetaFunction = () => {
 
 export const links: LinksFunction = () => {
   return [
-    { rel: "preload", href: "/fonts/Poppins-Regular.woff2", as: "font", type: "font/woff2", crossOrigin: "anonymous" },
-    { rel: "preload", href: "/fonts/Roboto-Regular.woff2", as: "font", type: "font/woff2", crossOrigin: "anonymous" },
+    {
+      rel: "preload",
+      href: "/fonts/Poppins-Regular.woff2",
+      as: "font",
+      type: "font/woff2",
+      crossOrigin: "anonymous",
+    },
+    {
+      rel: "preload",
+      href: "/fonts/Roboto-Regular.woff2",
+      as: "font",
+      type: "font/woff2",
+      crossOrigin: "anonymous",
+    },
     { rel: "stylesheet", href: styles },
     { rel: "icon", href: "/icon.png", type: "image/png" },
   ];

--- a/app/routes/$locale.tsx
+++ b/app/routes/$locale.tsx
@@ -42,7 +42,13 @@ export default function Wrapper({ loaderData }: Route.ComponentProps) {
   );
 }
 
-export function shouldRevalidate({ currentParams, nextParams }: { currentParams: Record<string, string>; nextParams: Record<string, string> }) {
+export function shouldRevalidate({
+  currentParams,
+  nextParams,
+}: {
+  currentParams: Record<string, string>;
+  nextParams: Record<string, string>;
+}) {
   return currentParams.locale !== nextParams.locale;
 }
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yml` running `npm run lint`, `npm run typecheck`, and `npm test -- --run` on every PR and on pushes to `main`. The repo previously had no CI for these — only Netlify deploy preview, CodeQL, and GitGuardian. Dependabot PRs could show "all green" while breaking the type system or tests.
- Includes a small auto-format-drift fix (3 files, pure Biome formatting, no logic change) so the new workflow passes from the first run.

## Why now

This is a prerequisite for safely merging the open Dependabot PRs (#350–#369): with this workflow in place, "green checks" actually means lint, types, and tests are still passing — not just that Netlify can build.

## Notes

- Uses `node-version-file: .nvmrc` so CI Node version stays in sync with the repo's pinned version.
- Does not run `npm run build` — Netlify already does that on the deploy preview, and CI would need Contentful env vars without adding signal.

## Test plan

- [ ] CI workflow itself runs green on this PR
- [ ] After merge, comment `@dependabot rebase` on a Dependabot PR (e.g. #354) and confirm the new check appears and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)